### PR TITLE
Feature of endpoint Activity

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,16 @@
             <artifactId>mysql-connector-j</artifactId>
             <scope>runtime</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>2.5.0</version>
+        </dependency>
+        <dependency>
+            <groupId>io.github.encryptorcode</groupId>
+            <artifactId>pluralize</artifactId>
+            <version>1.0.0</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/acme/nutrimove/platform/fitness/application/internal/commandservices/ActivityCommandServiceImpl.java
+++ b/src/main/java/com/acme/nutrimove/platform/fitness/application/internal/commandservices/ActivityCommandServiceImpl.java
@@ -1,0 +1,33 @@
+package com.acme.nutrimove.platform.fitness.application.internal.commandservices;
+
+import com.acme.nutrimove.platform.fitness.domain.model.aggregates.Activity;
+import com.acme.nutrimove.platform.fitness.domain.model.commands.CreateActivityCommand;
+import com.acme.nutrimove.platform.fitness.domain.model.queries.GetAllActivityByNameQuery;
+import com.acme.nutrimove.platform.fitness.domain.services.ActivityCommandService;
+import com.acme.nutrimove.platform.fitness.infrastructure.persistence.jpa.ActivityRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class ActivityCommandServiceImpl implements ActivityCommandService {
+
+    private final ActivityRepository activityRepository;
+
+    public ActivityCommandServiceImpl(ActivityRepository activityRepository) {
+        this.activityRepository = activityRepository;
+
+    }
+
+
+    @Override
+    public Optional<Activity> handle(CreateActivityCommand command) {
+        if (activityRepository.existsByNameAndDescription(command.name(), command.description())) {
+            throw new IllegalArgumentException("Favorite source with same source ID already exists for this news API key");
+        }
+        var activity = new Activity(command);
+        var createActivity = this.activityRepository.save(activity);
+        return Optional.of(createActivity);
+    }
+}

--- a/src/main/java/com/acme/nutrimove/platform/fitness/application/internal/queryservices/ActivityQueryServiceImpl.java
+++ b/src/main/java/com/acme/nutrimove/platform/fitness/application/internal/queryservices/ActivityQueryServiceImpl.java
@@ -1,0 +1,35 @@
+package com.acme.nutrimove.platform.fitness.application.internal.queryservices;
+
+import com.acme.nutrimove.platform.fitness.domain.model.aggregates.Activity;
+import com.acme.nutrimove.platform.fitness.domain.model.queries.GetActivityByIdQuery;
+import com.acme.nutrimove.platform.fitness.domain.model.queries.GetAllActivityByNameQuery;
+import com.acme.nutrimove.platform.fitness.domain.services.ActivityQueryService;
+import com.acme.nutrimove.platform.fitness.infrastructure.persistence.jpa.ActivityRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class ActivityQueryServiceImpl implements ActivityQueryService {
+    private final ActivityRepository activityRepository;
+
+    public ActivityQueryServiceImpl(ActivityRepository activityRepository) {
+        this.activityRepository = activityRepository;
+    }
+
+    @Override
+    public List<Activity> getAllActivities() {
+        return activityRepository.findAll();
+    }
+
+    @Override
+    public List<Activity> handle(GetAllActivityByNameQuery query) {
+        return activityRepository.findAllByName(query.name());
+    }
+
+    @Override
+    public Optional<Activity> handle(GetActivityByIdQuery query) {
+        return this.activityRepository.findById(query.id());
+    }
+}

--- a/src/main/java/com/acme/nutrimove/platform/fitness/domain/model/aggregates/Activity.java
+++ b/src/main/java/com/acme/nutrimove/platform/fitness/domain/model/aggregates/Activity.java
@@ -1,9 +1,9 @@
 package com.acme.nutrimove.platform.fitness.domain.model.aggregates;
-
+import com.acme.nutrimove.platform.fitness.domain.model.commands.CreateActivityCommand;
 import jakarta.persistence.*;
 import lombok.Getter;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.data.domain.AbstractAggregateRoot;
+
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
@@ -12,7 +12,7 @@ import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 @Getter
 @Entity
 @EntityListeners(AuditingEntityListener.class)
-public class Activity extends AbstractAggregateRoot<Activity> {
+public class Activity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -27,19 +27,19 @@ public class Activity extends AbstractAggregateRoot<Activity> {
 
     @Column(nullable = false)
     @Getter
-    private Float price;
+    private String duration;
 
     @Column(nullable = false)
     @Getter
-    private Integer monthDuration;
+    private Long userId;
 
-    @Column(nullable = false)
-    @Getter
-    private String trial;
+    public Activity(CreateActivityCommand command) {
+        this.name = command.name();
+        this.description = command.description();
+        this.duration = command.duration();
+        this.userId = command.user_id();
 
-    @Column(nullable = false)
-    @Getter
-    private String userId;
+    }
 
-    protected Activity() {}
+    public Activity() {}
 }

--- a/src/main/java/com/acme/nutrimove/platform/fitness/domain/model/commands/CreateActivityCommand.java
+++ b/src/main/java/com/acme/nutrimove/platform/fitness/domain/model/commands/CreateActivityCommand.java
@@ -1,0 +1,14 @@
+package com.acme.nutrimove.platform.fitness.domain.model.commands;
+
+
+public record CreateActivityCommand(String name, String description, String duration,
+                                    Long user_id) {
+
+    public CreateActivityCommand {
+        if (name == null || name.isBlank()) throw new IllegalArgumentException("name cannot be null or empty");
+        if (description == null || description.isBlank()) throw new IllegalArgumentException("description cannot be null or empty");
+        if (duration == null || duration.isBlank()) throw new IllegalArgumentException("duration cannot be null or empty");
+        if (user_id == null) throw new IllegalArgumentException("user_id cannot be null");
+
+    }
+}

--- a/src/main/java/com/acme/nutrimove/platform/fitness/domain/model/queries/GetActivityByIdQuery.java
+++ b/src/main/java/com/acme/nutrimove/platform/fitness/domain/model/queries/GetActivityByIdQuery.java
@@ -1,0 +1,7 @@
+package com.acme.nutrimove.platform.fitness.domain.model.queries;
+
+public record GetActivityByIdQuery(Long id) {
+    public GetActivityByIdQuery {
+        if (id == null) throw new NullPointerException("id is null");
+    }
+}

--- a/src/main/java/com/acme/nutrimove/platform/fitness/domain/model/queries/GetAllActivityByNameQuery.java
+++ b/src/main/java/com/acme/nutrimove/platform/fitness/domain/model/queries/GetAllActivityByNameQuery.java
@@ -1,0 +1,7 @@
+package com.acme.nutrimove.platform.fitness.domain.model.queries;
+
+public record GetAllActivityByNameQuery(String name) {
+    public GetAllActivityByNameQuery {
+        if (name == null) throw new NullPointerException("name is null");
+    }
+}

--- a/src/main/java/com/acme/nutrimove/platform/fitness/domain/services/ActivityCommandService.java
+++ b/src/main/java/com/acme/nutrimove/platform/fitness/domain/services/ActivityCommandService.java
@@ -1,0 +1,12 @@
+package com.acme.nutrimove.platform.fitness.domain.services;
+
+import com.acme.nutrimove.platform.fitness.domain.model.aggregates.Activity;
+import com.acme.nutrimove.platform.fitness.domain.model.commands.CreateActivityCommand;
+
+import java.util.Optional;
+
+public interface ActivityCommandService {
+
+    Optional<Activity> handle(CreateActivityCommand command);
+
+}

--- a/src/main/java/com/acme/nutrimove/platform/fitness/domain/services/ActivityQueryService.java
+++ b/src/main/java/com/acme/nutrimove/platform/fitness/domain/services/ActivityQueryService.java
@@ -1,0 +1,17 @@
+package com.acme.nutrimove.platform.fitness.domain.services;
+
+import com.acme.nutrimove.platform.fitness.domain.model.aggregates.Activity;
+import com.acme.nutrimove.platform.fitness.domain.model.commands.CreateActivityCommand;
+import com.acme.nutrimove.platform.fitness.domain.model.queries.GetActivityByIdQuery;
+import com.acme.nutrimove.platform.fitness.domain.model.queries.GetAllActivityByNameQuery;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ActivityQueryService {
+    List<Activity> handle(GetAllActivityByNameQuery query);
+    List<Activity> getAllActivities();
+
+    Optional<Activity> handle(GetActivityByIdQuery query);
+
+}

--- a/src/main/java/com/acme/nutrimove/platform/fitness/infrastructure/persistence/jpa/ActivityRepository.java
+++ b/src/main/java/com/acme/nutrimove/platform/fitness/infrastructure/persistence/jpa/ActivityRepository.java
@@ -1,0 +1,21 @@
+package com.acme.nutrimove.platform.fitness.infrastructure.persistence.jpa;
+
+import com.acme.nutrimove.platform.fitness.domain.model.aggregates.Activity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+
+/**
+ *JPA repository for Activity entity
+ @summary
+  * This interface extends JpaRepository, which provides CRUD operations for Activity entity.
+  * It extends JpaRepository<Activity, Long>, where Activity is the entity and Long is the type of the primary key.
+ */
+public interface ActivityRepository extends JpaRepository<Activity, Long> {
+    List<Activity> findAllByName(String name);
+
+   boolean existsByNameAndDescription(String name, String description);
+
+
+}

--- a/src/main/java/com/acme/nutrimove/platform/fitness/interfaces/rest/ActivityController.java
+++ b/src/main/java/com/acme/nutrimove/platform/fitness/interfaces/rest/ActivityController.java
@@ -1,0 +1,82 @@
+package com.acme.nutrimove.platform.fitness.interfaces.rest;
+
+import com.acme.nutrimove.platform.fitness.domain.model.aggregates.Activity;
+import com.acme.nutrimove.platform.fitness.domain.model.queries.GetActivityByIdQuery;
+import com.acme.nutrimove.platform.fitness.domain.model.queries.GetAllActivityByNameQuery;
+import com.acme.nutrimove.platform.fitness.domain.services.ActivityCommandService;
+import com.acme.nutrimove.platform.fitness.domain.services.ActivityQueryService;
+import com.acme.nutrimove.platform.fitness.interfaces.rest.resources.ActivityResource;
+import com.acme.nutrimove.platform.fitness.interfaces.rest.resources.CreateActivityResource;
+import com.acme.nutrimove.platform.fitness.interfaces.rest.transform.ActivityResourceFromEntityAssembler;
+import com.acme.nutrimove.platform.fitness.interfaces.rest.transform.CreateActivityCommandFromResourceAssembler;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.springframework.http.HttpStatus.CREATED;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
+@RestController
+@RequestMapping(value = "api/v1/activities", produces = APPLICATION_JSON_VALUE)
+@Tag(name = "Activities", description = "Operation related to Activities")
+public class ActivityController {
+    private final ActivityQueryService activityQueryService;
+    private final ActivityCommandService activityCommandService;
+
+    public ActivityController(ActivityQueryService activityQueryService, ActivityCommandService activityCommandService) {
+        this.activityQueryService = activityQueryService;
+        this.activityCommandService = activityCommandService;
+    }
+
+    @Operation(summary = "Create an activity", description = "Create an activity source with the provided news API")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "Activity created"),
+            @ApiResponse(responseCode = "400", description = "Bad Request"),
+    })
+
+    @PostMapping
+    public ResponseEntity<ActivityResource> createActivity(@RequestBody CreateActivityResource resource) {
+        Optional<Activity> activity = activityCommandService
+                .handle(CreateActivityCommandFromResourceAssembler.toCommand(resource));
+        return activity.map(source -> new ResponseEntity<>(ActivityResourceFromEntityAssembler.toResourceFromEntity(source), CREATED))
+                .orElseGet(() -> ResponseEntity.badRequest().build());
+    }
+
+    private ResponseEntity<List<ActivityResource>> getAllActivityByName(String name) {
+        var getAllActivityByNameQuery = new GetAllActivityByNameQuery(name);
+        var activities = activityQueryService.handle(getAllActivityByNameQuery);
+        if (activities.isEmpty()) {
+            return ResponseEntity.notFound().build();
+        }
+        var activityResources = activities.stream()
+                .map(ActivityResourceFromEntityAssembler::toResourceFromEntity)
+                .toList();
+        return ResponseEntity.ok(activityResources);
+    }
+
+    @GetMapping("{id}")
+    public ResponseEntity<ActivityResource> getFavoriteSourceById(@PathVariable Long id) {
+        Optional<Activity> activity = activityQueryService.handle(new GetActivityByIdQuery(id));
+        return activity.map(source -> ResponseEntity.ok(ActivityResourceFromEntityAssembler.toResourceFromEntity(source)))
+                .orElseGet(() -> ResponseEntity.notFound().build());
+    }
+
+    @GetMapping("")
+    public ResponseEntity<List<ActivityResource>> getAllActivities() {
+        var activities = activityQueryService.getAllActivities();
+        if (activities.isEmpty()) {
+            return ResponseEntity.notFound().build();
+        }
+        var activityResources = activities.stream()
+                .map(ActivityResourceFromEntityAssembler::toResourceFromEntity)
+                .toList();
+        return ResponseEntity.ok(activityResources);
+    }
+
+}

--- a/src/main/java/com/acme/nutrimove/platform/fitness/interfaces/rest/resources/ActivityResource.java
+++ b/src/main/java/com/acme/nutrimove/platform/fitness/interfaces/rest/resources/ActivityResource.java
@@ -1,0 +1,4 @@
+package com.acme.nutrimove.platform.fitness.interfaces.rest.resources;
+
+public record ActivityResource(Long id, String name, String description, String duration, Long userId ) {
+}

--- a/src/main/java/com/acme/nutrimove/platform/fitness/interfaces/rest/resources/CreateActivityResource.java
+++ b/src/main/java/com/acme/nutrimove/platform/fitness/interfaces/rest/resources/CreateActivityResource.java
@@ -1,0 +1,11 @@
+package com.acme.nutrimove.platform.fitness.interfaces.rest.resources;
+
+public record CreateActivityResource(String name, String description, String duration, Long userId ) {
+public CreateActivityResource {
+    if (name == null )throw new NullPointerException("name cannot be null");
+    if (description == null )throw new NullPointerException("description cannot be null");
+    if (duration == null )throw new NullPointerException("duration cannot be null");
+    if (userId == null )throw new NullPointerException("userId cannot be null");
+
+}
+}

--- a/src/main/java/com/acme/nutrimove/platform/fitness/interfaces/rest/transform/ActivityResourceFromEntityAssembler.java
+++ b/src/main/java/com/acme/nutrimove/platform/fitness/interfaces/rest/transform/ActivityResourceFromEntityAssembler.java
@@ -1,0 +1,11 @@
+package com.acme.nutrimove.platform.fitness.interfaces.rest.transform;
+
+import com.acme.nutrimove.platform.fitness.domain.model.aggregates.Activity;
+import com.acme.nutrimove.platform.fitness.interfaces.rest.resources.ActivityResource;
+
+public class ActivityResourceFromEntityAssembler {
+
+    public static ActivityResource toResourceFromEntity(Activity activity) {
+        return new ActivityResource(activity.getId(), activity.getName(), activity.getDescription(), activity.getDuration(), activity.getUserId());
+    }
+}

--- a/src/main/java/com/acme/nutrimove/platform/fitness/interfaces/rest/transform/CreateActivityCommandFromResourceAssembler.java
+++ b/src/main/java/com/acme/nutrimove/platform/fitness/interfaces/rest/transform/CreateActivityCommandFromResourceAssembler.java
@@ -1,0 +1,11 @@
+package com.acme.nutrimove.platform.fitness.interfaces.rest.transform;
+
+import com.acme.nutrimove.platform.fitness.domain.model.commands.CreateActivityCommand;
+import com.acme.nutrimove.platform.fitness.interfaces.rest.resources.CreateActivityResource;
+
+public class CreateActivityCommandFromResourceAssembler {
+
+    public static CreateActivityCommand toCommand(CreateActivityResource resource) {
+        return new CreateActivityCommand(resource.name(), resource.description(), resource.duration(), resource.userId());
+    }
+}

--- a/src/main/java/com/acme/nutrimove/platform/shared/OpenApiConfiguration.java
+++ b/src/main/java/com/acme/nutrimove/platform/shared/OpenApiConfiguration.java
@@ -1,0 +1,30 @@
+package com.acme.nutrimove.platform.shared;
+
+import io.swagger.v3.oas.models.ExternalDocumentation;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.info.License;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfiguration {
+    @Bean
+    public OpenAPI catchupOpenAPI(){
+        // General configuration
+        var openApi = new OpenAPI();
+
+        openApi
+                .info(new Info()
+                        .title("ACME Catchup Platform application REST API documentation.")
+                        .description("This is a sample Spring Boot RESTful service using springdoc-openapi and OpenAPI 3.")
+                        .version("v1.0.0")
+                        .license(new License().name("Apache 2.0")
+                                .url("http://springdoc.org")))
+                .externalDocs(new ExternalDocumentation()
+                        .description("ACME Catchup Platform wiki documentation")
+                        .url("https://acme-catchup-platform.wiki.github.io/docs"));
+        return openApi;
+
+    }
+}

--- a/src/main/java/com/acme/nutrimove/platform/shared/infrastructure/persistence/jpa/strategy/SnakeCasePhysicalNamingStrategy.java
+++ b/src/main/java/com/acme/nutrimove/platform/shared/infrastructure/persistence/jpa/strategy/SnakeCasePhysicalNamingStrategy.java
@@ -1,0 +1,61 @@
+package com.acme.nutrimove.platform.shared.infrastructure.persistence.jpa.strategy;
+
+import org.hibernate.boot.model.naming.Identifier;
+import org.hibernate.boot.model.naming.PhysicalNamingStrategy;
+import org.hibernate.engine.jdbc.env.spi.JdbcEnvironment;
+
+import static io.github.encryptorcode.pluralize.Pluralize.pluralize;
+
+public class SnakeCasePhysicalNamingStrategy  implements PhysicalNamingStrategy {
+    @Override
+    public Identifier toPhysicalCatalogName(Identifier identifier, JdbcEnvironment jdbcEnvironment) {
+        return this.toSnakeCase(identifier);
+    }
+
+    @Override
+    public Identifier toPhysicalSchemaName(Identifier identifier, JdbcEnvironment jdbcEnvironment) {
+        return this.toSnakeCase(identifier);
+    }
+
+    @Override
+    public Identifier toPhysicalTableName(Identifier identifier, JdbcEnvironment jdbcEnvironment) {
+        return this.toSnakeCase(this.toPlural(identifier));
+    }
+
+    @Override
+    public Identifier toPhysicalSequenceName(Identifier identifier, JdbcEnvironment jdbcEnvironment) {
+        return this.toSnakeCase(identifier);
+    }
+
+    @Override
+    public Identifier toPhysicalColumnName(Identifier identifier, JdbcEnvironment jdbcEnvironment) {
+        return this.toSnakeCase(identifier);
+    }
+
+    /**
+     * Convert the Identifier to Snake Case
+     * @param identifier object identifier
+     * @return Snake Case Identifier
+     */
+    private Identifier toSnakeCase(final Identifier identifier) {
+        if (identifier == null) {
+            return null;
+        }
+        final String regex = "([a-z])([A-Z])";
+        final String replacement = "$1_$2";
+        final String newName = identifier.getText()
+                .replaceAll(regex, replacement)
+                .toLowerCase();
+        return Identifier.toIdentifier(newName);
+    }
+
+    /**
+     * Pluralize the Identifier
+     * @param identifier object identifier
+     * @return Pluralized Identifier
+     */
+    private Identifier toPlural(final Identifier identifier){
+        final String name = pluralize(identifier.getText());
+        return Identifier.toIdentifier(name);
+    }
+}


### PR DESCRIPTION
This feature implements the Activity endpoint using JPA and a Domain-Driven Design (DDD) approach. It enables CRUD operations on the Activity entity, focusing on modularity and separation of concerns. The Activity controller provides endpoints for creating, retrieving, and listing activities. The JPA repository handles data persistence, while the service layer encapsulates business logic, ensuring a clean architecture that aligns with DDD principles. This setup enhances scalability and maintainability, allowing for easier future extensions.